### PR TITLE
添加对日志系统的支持

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,1 +1,3 @@
 # Docs
+
+[日志系统](logger.md)

--- a/docs/logger.md
+++ b/docs/logger.md
@@ -1,0 +1,3 @@
+# 日志系统
+
+1. <https://quuxplusone.github.io/blog/2021/11/09/pass-string-view-by-value/>

--- a/include/core/log.h
+++ b/include/core/log.h
@@ -1,26 +1,42 @@
 #ifndef PIORUN_CORE_LOG_H_
 #define PIORUN_CORE_LOG_H_
 
+#include <fstream>
+#include <mutex>
 #include <ostream>
-#include <string_view>
+
+#include "smartptr.h"
 
 namespace pio {
 namespace logger {
 
 enum Level {
-  FATAL = 0,
-  ERROR,
-  WARNING,
+  INFO = 1 << 0,
+  WARNING = 1 << 1,
+  ERROR = 1 << 2,
+  FATAL = 1 << 3,
 };
 
-void Begin(const std::string &logpath);
-void End();
+class Logger {
+ public:
+  ~Logger() {
+    if (logfile_.is_open()) logfile_.close();
+  }
 
-void Log(Level l, std::string_view msg);
+  static Ref<Logger> Create(const std::string& logpath);
 
-inline void Fatal(std::string_view msg) { Log(FATAL, msg); }
-inline void Error(std::string_view msg) { Log(ERROR, msg); }
-inline void Warning(std::string_view msg) { Log(WARNING, msg); }
+  inline void Fatal(std::string& msg) { Log(FATAL, msg); }
+  inline void Error(std::string& msg) { Log(ERROR, msg); }
+  inline void Warning(std::string& msg) { Log(WARNING, msg); }
+
+ private:
+  Logger(const std::string& logpath) { logfile_.open(logpath); }
+  void Log(Level l, std::string& msg);
+
+ private:
+  std::ofstream logfile_;
+  std::mutex mt_;
+};
 
 }  // namespace logger
 }  // namespace pio

--- a/include/core/log.h
+++ b/include/core/log.h
@@ -19,19 +19,20 @@ enum Level {
 
 class Logger {
  public:
+  Logger(const std::string& logpath) { logfile_.open(logpath); }
   ~Logger() {
     if (logfile_.is_open()) logfile_.close();
   }
 
   static Ref<Logger> Create(const std::string& logpath);
 
-  inline void Fatal(std::string& msg) { Log(FATAL, msg); }
-  inline void Error(std::string& msg) { Log(ERROR, msg); }
-  inline void Warning(std::string& msg) { Log(WARNING, msg); }
+  inline void Info(const std::string& msg) { Log(INFO, msg); }
+  inline void Warning(const std::string& msg) { Log(WARNING, msg); }
+  inline void Error(const std::string& msg) { Log(ERROR, msg); }
+  inline void Fatal(const std::string& msg) { Log(FATAL, msg); }
 
  private:
-  Logger(const std::string& logpath) { logfile_.open(logpath); }
-  void Log(Level l, std::string& msg);
+  void Log(Level l, const std::string& msg);
 
  private:
   std::ofstream logfile_;

--- a/include/core/smartptr.h
+++ b/include/core/smartptr.h
@@ -1,0 +1,22 @@
+#ifndef PIORUN_CORE_SMARTPTR_H_
+#define PIORUN_CORE_SMARTPTR_H_
+
+#include <memory>
+
+template <typename T>
+using Scope = std::unique_ptr<T>;
+
+template <typename T, typename... Args>
+constexpr Scope<T> CreateScope(Args&&... args) {
+  return std::make_unique<T>(std::forward<Args>(args)...);
+}
+
+template <typename T>
+using Ref = std::shared_ptr<T>;
+
+template <typename T, typename... Args>
+constexpr Ref<T> CreateRef(Args&&... args) {
+  return std::make_shared<T>(std::forward<Args>(args)...);
+}
+
+#endif  // !PIORUN_CORE_SMARTPTR_H_

--- a/include/piorun.h
+++ b/include/piorun.h
@@ -1,4 +1,6 @@
 #ifndef PIORUN_H_
 #define PIORUN_H_
 
-#endif // !PIORUN_H_
+#include "core/log.h"
+
+#endif  // !PIORUN_H_

--- a/src/piorun/CMakeLists.txt
+++ b/src/piorun/CMakeLists.txt
@@ -1,3 +1,5 @@
 add_library(piorun piorun.cc)
 
 target_include_directories(piorun PUBLIC ${PROJECT_SOURCE_DIR}/include)
+
+add_subdirectory(core)

--- a/src/piorun/core/CMakeLists.txt
+++ b/src/piorun/core/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_sources(piorun PUBLIC log.cc)

--- a/src/piorun/core/log.cc
+++ b/src/piorun/core/log.cc
@@ -1,15 +1,9 @@
 #include "core/log.h"
 
-#include <fstream>
-#include <mutex>
+#include "core/smartptr.h"
 
 namespace pio {
 namespace logger {
-
-namespace {
-std::ofstream logfile;
-std::mutex mt;
-}  // namespace
 
 std::ostream &operator<<(std::ostream &os, const Level &l) {
   switch (l) {
@@ -29,13 +23,14 @@ std::ostream &operator<<(std::ostream &os, const Level &l) {
   return os;
 }
 
-void Setup(const std::string &logpath) { logfile.open(logpath); }
-void Close() { logfile.close(); }
+Ref<Logger> Logger::Create(const std::string &logpath) {
+  return CreateRef<Logger>(logpath);
+}
 
-void Log(Level l, std::string_view msg) {
-  std::lock_guard<std::mutex> lk(mt);
-  if (logfile.is_open()) {
-    logfile << l << ": " << msg << '\n';
+void Logger::Log(Level l, std::string &msg) {
+  std::lock_guard<std::mutex> lk(mt_);
+  if (logfile_.is_open()) {
+    logfile_ << l << ": " << msg << '\n';
   }
 }
 

--- a/src/piorun/core/log.cc
+++ b/src/piorun/core/log.cc
@@ -7,14 +7,17 @@ namespace logger {
 
 std::ostream &operator<<(std::ostream &os, const Level &l) {
   switch (l) {
-    case FATAL:
-      os << "Fatal";
-      break;
-    case ERROR:
-      os << "Error";
+    case INFO:
+      os << "[Info]";
       break;
     case WARNING:
-      os << "Warning";
+      os << "[Warning]";
+      break;
+    case ERROR:
+      os << "[Error]";
+      break;
+    case FATAL:
+      os << "[Fatal]";
       break;
     default:
       break;
@@ -27,7 +30,7 @@ Ref<Logger> Logger::Create(const std::string &logpath) {
   return CreateRef<Logger>(logpath);
 }
 
-void Logger::Log(Level l, std::string &msg) {
+void Logger::Log(Level l, const std::string &msg) {
   std::lock_guard<std::mutex> lk(mt_);
   if (logfile_.is_open()) {
     logfile_ << l << ": " << msg << '\n';

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,2 +1,5 @@
 add_executable(test test.cc)
 target_link_libraries(test piorun)
+
+add_executable(test_log test_log.cc)
+target_link_libraries(test_log piorun)

--- a/tests/test_log.cc
+++ b/tests/test_log.cc
@@ -1,0 +1,13 @@
+#include <iostream>
+
+#include "core/log.h"
+
+int main() {
+  using namespace pio::logger;
+  auto logger = Logger::Create("piorun_test.log");
+
+  logger->Info("This is a test");
+  logger->Warning("This is a test");
+  logger->Error("This is a test");
+  logger->Fatal("This is a test");
+}


### PR DESCRIPTION
## 1. 对智能指针的封装

```cc
template <typename T>
using Scope = std::unique_ptr<T>;

template <typename T, typename... Args>
constexpr Scope<T> CreateScope(Args&&... args) {
  return std::make_unique<T>(std::forward<Args>(args)...);
}

template <typename T>
using Ref = std::shared_ptr<T>;

template <typename T, typename... Args>
constexpr Ref<T> CreateRef(Args&&... args) {
  return std::make_shared<T>(std::forward<Args>(args)...);
}
```

使用 Scope 封装 unique_ptr，可以使用 CreateScope 创建
使用 Ref 封装 shared_ptr，可以使用 CreateRef 创建

## 2. 支持多个日志级别

- INFO: 表示一般信息
- WARNING: 表示警告信息
- ERROR: 表示错误信息
- FATAL: 表示重大错误

## 3. 支持多线程

主要包括两个方面：
1. 使用 mutex 锁
2. 使用 Ref 指针，可以在多个线程共享一个日志对象

## 4. API

1. 创建: `Logger::Create(path)`
2. 对于四个日志级别，有着相对应的方法，如对于 INFO，有 logger->Info(msg)
3. 无需手动释放内存

## 5. 示例

```cc
int main() {
  using namespace pio::logger;
  auto logger = Logger::Create("piorun_test.log");

  logger->Info("This is a test");
  logger->Warning("This is a test");
  logger->Error("This is a test");
  logger->Fatal("This is a test");
}
```

输出：

```txt
[Info]: This is a test
[Warning]: This is a test
[Error]: This is a test
[Fatal]: This is a test
```