### PR TITLE
feat: rio and echo server test

### DIFF
--- a/include/coroutine/async/async_read.h
+++ b/include/coroutine/async/async_read.h
@@ -8,8 +8,10 @@
 
 namespace pio {
 
-task::Chainable AsyncRead(SocketView s, std::span<std::byte> &data);
+task::Chainable AsyncRead(SocketView s, std::span<std::byte>& data);
 
-}
+task::Chainable AsyncRead(SocketView s, char* buffer);
+
+}  // namespace pio
 
 #endif  // PIORUN_COROUTINE_ASYNC_READ_H_

--- a/include/coroutine/async/async_write.h
+++ b/include/coroutine/async/async_write.h
@@ -2,13 +2,15 @@
 #define PIORUN_COROUTINE_ASYNC_WRITE_H_
 
 #include <span>
+
 #include "coroutine/task/chainable.h"
 #include "socket.h"
 
 namespace pio {
 
-task::Chainable AsyncWrite(SocketView s, std::span<const std::byte> &data);
+task::Chainable AsyncWrite(SocketView s, std::span<const std::byte>& data);
 
-}
+task::Chainable AsyncWrite(SocketView s, char* buffer, size_t n);
+}  // namespace pio
 
 #endif  // PIORUN_COROUTINE_ASYNC_WRITE_H_

--- a/src/piorun/coroutine/async/async_write.cc
+++ b/src/piorun/coroutine/async/async_write.cc
@@ -7,7 +7,7 @@
 
 namespace pio {
 
-task::Chainable AsyncWrite(SocketView s, std::span<const std::byte> &data) {
+task::Chainable AsyncWrite(SocketView s, std::span<const std::byte>& data) {
   while (data.size() > 0) {
     ssize_t cnt = write(s->fd_, data.data(), data.size());
     if (cnt == -1 && errno != EAGAIN)
@@ -22,6 +22,37 @@ task::Chainable AsyncWrite(SocketView s, std::span<const std::byte> &data) {
                                                      s->fd_, s.deadline());
         !status) {
       co_return status;
+    }
+  }
+  co_return awaitable::Result{EventType::WAKEUP, 0, ""};
+}
+
+// write其实不需要等待，因为写缓存区基本都是可写的
+// 并且如果将写操作也注册为事件，会出现bug
+// 主要就在于epoll_wait可能感知不到socket可写，所以并不会执行真正的写操作
+// 因此client就会一直被搁置
+task::Chainable AsyncWrite(SocketView s, char* buffer, size_t n) {
+  // if (auto status = co_await MainScheduler().Event(EventCategory::EPOLL,
+  // s->fd_,
+  //                                                  s.deadline());
+  //     !status) {
+  //   co_return status;
+  // }
+  size_t nleft = n;
+  ssize_t nwritten;
+  char* buf = buffer;
+  while (nleft > 0) {
+    nwritten = write(s->fd_, buf, nleft);
+    if (nwritten < 0) {
+      if (errno == EAGAIN) {
+        break;
+      } else {
+        co_return awaitable::Result{EventType::ERROR, errno,
+                                    "Failed to write data to socket."};
+      }
+    } else {
+      nleft -= nwritten;
+      buf += nwritten;
     }
   }
   co_return awaitable::Result{EventType::WAKEUP, 0, ""};

--- a/src/piorun/coroutine/async/async_write.cc
+++ b/src/piorun/coroutine/async/async_write.cc
@@ -32,12 +32,6 @@ task::Chainable AsyncWrite(SocketView s, std::span<const std::byte>& data) {
 // 主要就在于epoll_wait可能感知不到socket可写，所以并不会执行真正的写操作
 // 因此client就会一直被搁置
 task::Chainable AsyncWrite(SocketView s, char* buffer, size_t n) {
-  // if (auto status = co_await MainScheduler().Event(EventCategory::EPOLL,
-  // s->fd_,
-  //                                                  s.deadline());
-  //     !status) {
-  //   co_return status;
-  // }
   size_t nleft = n;
   ssize_t nwritten;
   char* buf = buffer;


### PR DESCRIPTION
1. 主要请看AsyncWrite的实现上方的注释
2. 目前的感受是如果是当前的设计，read和accept等操作类似于异步操作（因为操作都是在新的协程里完成的，在调用的协程中执行过程中都是被挂起的，操作完成则会返回结果）